### PR TITLE
Fixed compilation on Rust 1.3.0 stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,6 @@ repository = "https://github.com/bjz/algebra"
 [lib]
 name = "algebra"
 
-[dev_dependencies.quickcheck]
-git = "https://github.com/BurntSushi/quickcheck"
-
-[dev_dependencies.quickcheck_macros]
-git = "https://github.com/BurntSushi/quickcheck"
+[dev-dependencies]
+quickcheck = "0.2"
+quickcheck_macros = "0.2"

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::num::{Float, SignedInt};
-
 /// A type with an approximate equivalence relation.
-pub trait ApproxEq<Eps> {
+pub trait ApproxEq<Eps> : Sized {
     /// The default epsilon value to use in `ApproxEq::approx_eq`.
     fn default_epsilon(_: Option<Self>) -> Eps;
 
@@ -73,15 +71,13 @@ macro_rules! impl_approx_eq_for_float {
     }
 }
 
-impl_approx_eq_for_uint!(u8)
-impl_approx_eq_for_uint!(u16)
-impl_approx_eq_for_uint!(u32)
-impl_approx_eq_for_uint!(u64)
-impl_approx_eq_for_uint!(uint)
-impl_approx_eq_for_int!(i8)
-impl_approx_eq_for_int!(i16)
-impl_approx_eq_for_int!(i32)
-impl_approx_eq_for_int!(i64)
-impl_approx_eq_for_int!(int)
-impl_approx_eq_for_float!(f32)
-impl_approx_eq_for_float!(f64)
+impl_approx_eq_for_uint!(u8);
+impl_approx_eq_for_uint!(u16);
+impl_approx_eq_for_uint!(u32);
+impl_approx_eq_for_uint!(u64);
+impl_approx_eq_for_int!(i8);
+impl_approx_eq_for_int!(i16);
+impl_approx_eq_for_int!(i32);
+impl_approx_eq_for_int!(i64);
+impl_approx_eq_for_float!(f32);
+impl_approx_eq_for_float!(f64);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,9 @@
 
 //! Traits for generic mathematics.
 
-#![feature(globs)]
-#![feature(macro_rules)]
-#![feature(phase)]
+#![cfg_attr(test, feature(plugin))]
+#![cfg_attr(test, plugin(quickcheck_macros))]
 
-#[cfg(test)]
-#[phase(plugin)]
-extern crate quickcheck_macros;
 #[cfg(test)]
 extern crate quickcheck;
 

--- a/src/structure/abelian.rs
+++ b/src/structure/abelian.rs
@@ -26,20 +26,18 @@ pub trait GroupAdditiveAbelianApprox
     /// the given argument tuple.
     fn prop_add_is_commutative_approx(args: (Self, Self)) -> bool {
         let (a, b) = args;
-        a + b == b + a
+        a.clone() + b.clone() == b + a
     }
 }
 
-impl GroupAdditiveAbelianApprox for u8   {}
-impl GroupAdditiveAbelianApprox for u16  {}
-impl GroupAdditiveAbelianApprox for u32  {}
-impl GroupAdditiveAbelianApprox for u64  {}
-impl GroupAdditiveAbelianApprox for uint {}
+//impl GroupAdditiveAbelianApprox for u8   {}
+//impl GroupAdditiveAbelianApprox for u16  {}
+//impl GroupAdditiveAbelianApprox for u32  {}
+//impl GroupAdditiveAbelianApprox for u64  {}
 impl GroupAdditiveAbelianApprox for i8   {}
 impl GroupAdditiveAbelianApprox for i16  {}
 impl GroupAdditiveAbelianApprox for i32  {}
 impl GroupAdditiveAbelianApprox for i64  {}
-impl GroupAdditiveAbelianApprox for int  {}
 
 pub trait GroupAdditiveAbelian
     : GroupAdditiveAbelianApprox
@@ -49,20 +47,18 @@ pub trait GroupAdditiveAbelian
     /// argument tuple.
     fn prop_add_is_commutative(args: (Self, Self)) -> bool {
         let (a, b) = args;
-        a + b == b + a
+        a.clone() + b.clone() == b + a
     }
 }
 
-impl GroupAdditiveAbelian for u8   {}
-impl GroupAdditiveAbelian for u16  {}
-impl GroupAdditiveAbelian for u32  {}
-impl GroupAdditiveAbelian for u64  {}
-impl GroupAdditiveAbelian for uint {}
+//impl GroupAdditiveAbelian for u8   {}
+//impl GroupAdditiveAbelian for u16  {}
+//impl GroupAdditiveAbelian for u32  {}
+//impl GroupAdditiveAbelian for u64  {}
 impl GroupAdditiveAbelian for i8   {}
 impl GroupAdditiveAbelian for i16  {}
 impl GroupAdditiveAbelian for i32  {}
 impl GroupAdditiveAbelian for i64  {}
-impl GroupAdditiveAbelian for int  {}
 
 pub trait GroupMultiplicativeAbelianApprox
     : GroupMultiplicativeApprox
@@ -71,7 +67,7 @@ pub trait GroupMultiplicativeAbelianApprox
     /// commutative for the given argument tuple.
     fn prop_mul_is_commutative_approx(args: (Self, Self)) -> bool {
         let (a, b) = args;
-        a * b == b * a
+        a.clone() * b.clone() == b * a
     }
 }
 
@@ -83,6 +79,6 @@ pub trait GroupMultiplicativeAbelian
     /// given argument tuple.
     fn prop_mul_is_commutative(args: (Self, Self)) -> bool {
         let (a, b) = args;
-        a * b == b * a
+        a.clone() * b.clone() == b * a
     }
 }

--- a/src/structure/group.rs
+++ b/src/structure/group.rs
@@ -28,16 +28,14 @@ pub trait GroupAdditiveApprox
     + MonoidAdditiveApprox
 {}
 
-impl GroupAdditiveApprox for u8   {}
-impl GroupAdditiveApprox for u16  {}
-impl GroupAdditiveApprox for u32  {}
-impl GroupAdditiveApprox for u64  {}
-impl GroupAdditiveApprox for uint {}
+//impl GroupAdditiveApprox for u8   {}
+//impl GroupAdditiveApprox for u16  {}
+//impl GroupAdditiveApprox for u32  {}
+//impl GroupAdditiveApprox for u64  {}
 impl GroupAdditiveApprox for i8   {}
 impl GroupAdditiveApprox for i16  {}
 impl GroupAdditiveApprox for i32  {}
 impl GroupAdditiveApprox for i64  {}
-impl GroupAdditiveApprox for int  {}
 
 pub trait GroupAdditive
     : GroupAdditiveApprox
@@ -45,16 +43,14 @@ pub trait GroupAdditive
     + MonoidAdditive
 {}
 
-impl GroupAdditive for u8   {}
-impl GroupAdditive for u16  {}
-impl GroupAdditive for u32  {}
-impl GroupAdditive for u64  {}
-impl GroupAdditive for uint {}
+//impl GroupAdditive for u8   {}
+//impl GroupAdditive for u16  {}
+//impl GroupAdditive for u32  {}
+//impl GroupAdditive for u64  {}
 impl GroupAdditive for i8   {}
 impl GroupAdditive for i16  {}
 impl GroupAdditive for i32  {}
 impl GroupAdditive for i64  {}
-impl GroupAdditive for int  {}
 
 pub trait GroupMultiplicativeApprox
     : LoopMultiplicativeApprox

--- a/src/structure/ident.rs
+++ b/src/structure/ident.rs
@@ -14,9 +14,11 @@
 
 //! Identities for binary operators
 
+use std::ops::{Add, Mul};
+
 /// A type that is equipped with an additive identity.
 pub trait IdentityAdditive
-    : Add<Self, Self>
+    : Add<Self, Output=Self>
 {
     /// The additive identity element, `0`.
     fn zero() -> Self;
@@ -26,12 +28,10 @@ impl IdentityAdditive for u8   { #[inline] fn zero() -> u8   { 0   } }
 impl IdentityAdditive for u16  { #[inline] fn zero() -> u16  { 0   } }
 impl IdentityAdditive for u32  { #[inline] fn zero() -> u32  { 0   } }
 impl IdentityAdditive for u64  { #[inline] fn zero() -> u64  { 0   } }
-impl IdentityAdditive for uint { #[inline] fn zero() -> uint { 0   } }
 impl IdentityAdditive for i8   { #[inline] fn zero() -> i8   { 0   } }
 impl IdentityAdditive for i16  { #[inline] fn zero() -> i16  { 0   } }
 impl IdentityAdditive for i32  { #[inline] fn zero() -> i32  { 0   } }
 impl IdentityAdditive for i64  { #[inline] fn zero() -> i64  { 0   } }
-impl IdentityAdditive for int  { #[inline] fn zero() -> int  { 0   } }
 impl IdentityAdditive for f32  { #[inline] fn zero() -> f32  { 0.0 } }
 impl IdentityAdditive for f64  { #[inline] fn zero() -> f64  { 0.0 } }
 
@@ -42,7 +42,7 @@ pub fn zero<T: IdentityAdditive>() -> T {
 
 /// A type that is equipped with a multiplicative identity.
 pub trait IdentityMultiplicative
-    : Mul<Self, Self>
+    : Mul<Self, Output=Self>
 {
     /// The multiplicative identity element, `1`.
     fn unit() -> Self;
@@ -52,12 +52,10 @@ impl IdentityMultiplicative for u8   { #[inline] fn unit() -> u8   { 1   } }
 impl IdentityMultiplicative for u16  { #[inline] fn unit() -> u16  { 1   } }
 impl IdentityMultiplicative for u32  { #[inline] fn unit() -> u32  { 1   } }
 impl IdentityMultiplicative for u64  { #[inline] fn unit() -> u64  { 1   } }
-impl IdentityMultiplicative for uint { #[inline] fn unit() -> uint { 1   } }
 impl IdentityMultiplicative for i8   { #[inline] fn unit() -> i8   { 1   } }
 impl IdentityMultiplicative for i16  { #[inline] fn unit() -> i16  { 1   } }
 impl IdentityMultiplicative for i32  { #[inline] fn unit() -> i32  { 1   } }
 impl IdentityMultiplicative for i64  { #[inline] fn unit() -> i64  { 1   } }
-impl IdentityMultiplicative for int  { #[inline] fn unit() -> int  { 1   } }
 impl IdentityMultiplicative for f32  { #[inline] fn unit() -> f32  { 1.0 } }
 impl IdentityMultiplicative for f64  { #[inline] fn unit() -> f64  { 1.0 } }
 

--- a/src/structure/loop_.rs
+++ b/src/structure/loop_.rs
@@ -25,16 +25,14 @@ pub trait LoopAdditiveApprox
     + IdentityAdditive
 {}
 
-impl LoopAdditiveApprox for u8   {}
-impl LoopAdditiveApprox for u16  {}
-impl LoopAdditiveApprox for u32  {}
-impl LoopAdditiveApprox for u64  {}
-impl LoopAdditiveApprox for uint {}
+//impl LoopAdditiveApprox for u8   {}
+//impl LoopAdditiveApprox for u16  {}
+//impl LoopAdditiveApprox for u32  {}
+//impl LoopAdditiveApprox for u64  {}
 impl LoopAdditiveApprox for i8   {}
 impl LoopAdditiveApprox for i16  {}
 impl LoopAdditiveApprox for i32  {}
 impl LoopAdditiveApprox for i64  {}
-impl LoopAdditiveApprox for int  {}
 
 /// An additive quasigroup with a corresponding identity.
 pub trait LoopAdditive
@@ -42,16 +40,14 @@ pub trait LoopAdditive
     + QuasigroupAdditive
 {}
 
-impl LoopAdditive for u8   {}
-impl LoopAdditive for u16  {}
-impl LoopAdditive for u32  {}
-impl LoopAdditive for u64  {}
-impl LoopAdditive for uint {}
+//impl LoopAdditive for u8   {}
+//impl LoopAdditive for u16  {}
+//impl LoopAdditive for u32  {}
+//impl LoopAdditive for u64  {}
 impl LoopAdditive for i8   {}
 impl LoopAdditive for i16  {}
 impl LoopAdditive for i32  {}
 impl LoopAdditive for i64  {}
-impl LoopAdditive for int  {}
 
 /// An aproximate multiplicative quasigroup with a corresponding identity.
 pub trait LoopMultiplicativeApprox

--- a/src/structure/magma.rs
+++ b/src/structure/magma.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ops::{Add, Mul};
+
 /// An additive closure that forms a partial equivalence relation.
 ///
 /// ~~~notrust
@@ -19,13 +21,15 @@
 /// a + b ∈ Self        ∀ a, b ∈ Self
 /// ~~~
 pub trait MagmaAdditiveApprox
-    : Add<Self, Self>
+    : Add<Self, Output=Self>
 //  + ApproxEq (TODO: requires better support for associated types)
     + PartialEq
+    + Sized
+    + Clone
 {}
 
 impl<T> MagmaAdditiveApprox for T where
-    T: Add<T, T> /*+ ApproxEq*/ + PartialEq,
+    T: Add<T, Output=T> /*+ ApproxEq*/ + PartialEq + Clone,
 {}
 
 /// An additive closure that forms an equivalence relation.
@@ -50,13 +54,15 @@ impl<T> MagmaAdditive for T where
 /// a * b ∈ Self        ∀ a, b ∈ Self
 /// ~~~
 pub trait MagmaMultiplicativeApprox
-    : Mul<Self, Self>
+    : Mul<Self, Output=Self>
 //  + ApproxEq (TODO: requires better support for associated types)
     + PartialEq
+    + Sized
+    + Clone
 {}
 
 impl<T> MagmaMultiplicativeApprox for T where
-    T: Mul<T, T> /*+ ApproxEq*/ + PartialEq,
+    T: Mul<T, Output=T> /*+ ApproxEq*/ + PartialEq + Clone,
 {}
 
 /// A multiplicative closure that forms an equivalence relation.

--- a/src/structure/monoid.rs
+++ b/src/structure/monoid.rs
@@ -33,8 +33,8 @@ pub trait MonoidAdditiveApprox
     /// Checks whether adding `0` is approximately a no-op for the given
     /// argument.
     fn prop_add_zero_is_noop_approx(a: Self) -> bool {
-        a + zero::<Self>() == a &&
-        zero::<Self>() + a == a
+        a.clone() + zero::<Self>() == a.clone() &&
+        zero::<Self>() + a.clone() == a.clone()
     }
 }
 
@@ -42,12 +42,10 @@ impl MonoidAdditiveApprox for u8   {}
 impl MonoidAdditiveApprox for u16  {}
 impl MonoidAdditiveApprox for u32  {}
 impl MonoidAdditiveApprox for u64  {}
-impl MonoidAdditiveApprox for uint {}
 impl MonoidAdditiveApprox for i8   {}
 impl MonoidAdditiveApprox for i16  {}
 impl MonoidAdditiveApprox for i32  {}
 impl MonoidAdditiveApprox for i64  {}
-impl MonoidAdditiveApprox for int  {}
 
 /// A type that is equipped with an associative addition operator and a
 /// corresponding identity. This should satisfy:
@@ -62,8 +60,8 @@ pub trait MonoidAdditive
 {
     /// Checks whether adding `0` is a no-op for the given argument.
     fn prop_add_zero_is_noop(a: Self) -> bool {
-        a + zero::<Self>() == a &&
-        zero::<Self>() + a == a
+        a.clone() + zero::<Self>() == a.clone() &&
+        zero::<Self>() + a.clone() == a.clone()
     }
 }
 
@@ -71,12 +69,10 @@ impl MonoidAdditive for u8   {}
 impl MonoidAdditive for u16  {}
 impl MonoidAdditive for u32  {}
 impl MonoidAdditive for u64  {}
-impl MonoidAdditive for uint {}
 impl MonoidAdditive for i8   {}
 impl MonoidAdditive for i16  {}
 impl MonoidAdditive for i32  {}
 impl MonoidAdditive for i64  {}
-impl MonoidAdditive for int  {}
 
 /// A type that is equipped with an approximately associative multiplication
 /// operator and a corresponding identity. This should satisfy:
@@ -92,8 +88,8 @@ pub trait MonoidMultiplicativeApprox
     /// Checks whether multiplying by `1` is approximately a no-op for the given
     /// argument.
     fn prop_mul_unit_is_noop_approx(a: Self) -> bool {
-        a * unit::<Self>() == a &&
-        unit::<Self>() * a == a
+        a.clone() * unit::<Self>() == a.clone() &&
+        unit::<Self>() * a.clone() == a.clone()
     }
 }
 
@@ -101,12 +97,10 @@ impl MonoidMultiplicativeApprox for u8   {}
 impl MonoidMultiplicativeApprox for u16  {}
 impl MonoidMultiplicativeApprox for u32  {}
 impl MonoidMultiplicativeApprox for u64  {}
-impl MonoidMultiplicativeApprox for uint {}
 impl MonoidMultiplicativeApprox for i8   {}
 impl MonoidMultiplicativeApprox for i16  {}
 impl MonoidMultiplicativeApprox for i32  {}
 impl MonoidMultiplicativeApprox for i64  {}
-impl MonoidMultiplicativeApprox for int  {}
 
 /// A type that is equipped with an associative multiplication operator and a
 /// corresponding identity. This should satisfy:
@@ -121,8 +115,8 @@ pub trait MonoidMultiplicative
 {
     /// Checks whether multiplying by `1` is a no-op for the given argument.
     fn prop_mul_unit_is_noop(a: Self) -> bool {
-        a * unit::<Self>() == a &&
-        unit::<Self>() * a == a
+        a.clone() * unit::<Self>() == a.clone() &&
+        unit::<Self>() * a.clone() == a.clone()
     }
 }
 
@@ -130,12 +124,10 @@ impl MonoidMultiplicative for u8   {}
 impl MonoidMultiplicative for u16  {}
 impl MonoidMultiplicative for u32  {}
 impl MonoidMultiplicative for u64  {}
-impl MonoidMultiplicative for uint {}
 impl MonoidMultiplicative for i8   {}
 impl MonoidMultiplicative for i16  {}
 impl MonoidMultiplicative for i32  {}
 impl MonoidMultiplicative for i64  {}
-impl MonoidMultiplicative for int  {}
 
 #[cfg(test)]
 mod tests {
@@ -167,14 +159,12 @@ mod tests {
             }
         }
     }
-    check_int!(u8)
-    check_int!(u16)
-    check_int!(u32)
-    check_int!(u64)
-    check_int!(uint)
-    check_int!(i8)
-    check_int!(i16)
-    check_int!(i32)
-    check_int!(i64)
-    check_int!(int)
+    check_int!(u8);
+    check_int!(u16);
+    check_int!(u32);
+    check_int!(u64);
+    check_int!(i8);
+    check_int!(i16);
+    check_int!(i32);
+    check_int!(i64);
 }

--- a/src/structure/quasigroup.rs
+++ b/src/structure/quasigroup.rs
@@ -11,8 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 #![allow(missing_docs)]
+
+use std::ops::{Sub, Neg, Div};
 
 use ops::Recip;
 use structure::MagmaAdditiveApprox;
@@ -23,31 +24,29 @@ use structure::MagmaMultiplicative;
 /// An additive magma that for which subtraction is always possible.
 pub trait QuasigroupAdditiveApprox
     : MagmaAdditiveApprox
-    + Sub<Self, Self>
-    + Neg<Self>
+    + Sub<Self, Output=Self>
+    + Neg<Output=Self>
 {
     fn prop_sub_is_latin_square_approx(args: (Self, Self)) -> bool {
         let (a, b) = args;
 
-        a == (a + -b) + b &&
-        a == (a + b) + -b &&
-        a == (a - b) + b &&
-        a == (a + b) - b
+        a.clone() == (a.clone() + -b.clone()) + b.clone() &&
+        a.clone() == (a.clone() + b.clone()) + -b.clone() &&
+        a.clone() == (a.clone() - b.clone()) + b.clone() &&
+        a.clone() == (a.clone() + b.clone()) - b.clone()
 
         // TODO: psuedo inverse?
     }
 }
 
-impl QuasigroupAdditiveApprox for u8   {}
-impl QuasigroupAdditiveApprox for u16  {}
-impl QuasigroupAdditiveApprox for u32  {}
-impl QuasigroupAdditiveApprox for u64  {}
-impl QuasigroupAdditiveApprox for uint {}
+//impl QuasigroupAdditiveApprox for u8   {}
+//impl QuasigroupAdditiveApprox for u16  {}
+//impl QuasigroupAdditiveApprox for u32  {}
+//impl QuasigroupAdditiveApprox for u64  {}
 impl QuasigroupAdditiveApprox for i8   {}
 impl QuasigroupAdditiveApprox for i16  {}
 impl QuasigroupAdditiveApprox for i32  {}
 impl QuasigroupAdditiveApprox for i64  {}
-impl QuasigroupAdditiveApprox for int  {}
 
 /// An additive magma that for which subtraction is always possible.
 pub trait QuasigroupAdditive
@@ -57,39 +56,37 @@ pub trait QuasigroupAdditive
     fn prop_sub_is_latin_square(args: (Self, Self)) -> bool {
         let (a, b) = args;
 
-        a == (a + -b) + b &&
-        a == (a + b) + -b &&
-        a == (a - b) + b &&
-        a == (a + b) - b
+        a.clone() == (a.clone() + -b.clone()) + b.clone() &&
+        a.clone() == (a.clone() + b.clone()) + -b.clone() &&
+        a.clone() == (a.clone() - b.clone()) + b.clone() &&
+        a.clone() == (a.clone() + b.clone()) - b.clone()
 
         // TODO: psuedo inverse?
     }
 }
 
-impl QuasigroupAdditive for u8   {}
-impl QuasigroupAdditive for u16  {}
-impl QuasigroupAdditive for u32  {}
-impl QuasigroupAdditive for u64  {}
-impl QuasigroupAdditive for uint {}
+//impl QuasigroupAdditive for u8   {}
+//impl QuasigroupAdditive for u16  {}
+//impl QuasigroupAdditive for u32  {}
+//impl QuasigroupAdditive for u64  {}
 impl QuasigroupAdditive for i8   {}
 impl QuasigroupAdditive for i16  {}
 impl QuasigroupAdditive for i32  {}
 impl QuasigroupAdditive for i64  {}
-impl QuasigroupAdditive for int  {}
 
 /// An multiplicative magma that for which division is always possible.
 pub trait QuasigroupMultiplicativeApprox
     : MagmaMultiplicativeApprox
-    + Div<Self, Self>
+    + Div<Self, Output=Self>
     + Recip<Self>
 {
     fn prop_div_is_latin_square_approx(args: (Self, Self)) -> bool {
         let (a, b) = args;
 
-        a == (a * b.recip()) * b &&
-        a == (a * b) * b.recip() &&
-        a == (a / b) * b &&
-        a == (a * b) / b
+        a.clone() == (a.clone() * b.clone().recip()) * b.clone() &&
+        a.clone() == (a.clone() * b.clone()) * b.clone().recip() &&
+        a.clone() == (a.clone() / b.clone()) * b.clone() &&
+        a.clone() == (a.clone() * b.clone()) / b.clone()
 
         // TODO: psuedo inverse?
     }
@@ -103,10 +100,10 @@ pub trait QuasigroupMultiplicative
     fn prop_div_is_latin_square(args: (Self, Self)) -> bool {
         let (a, b) = args;
 
-        a == (a * b.recip()) * b &&
-        a == (a * b) * b.recip() &&
-        a == (a / b) * b &&
-        a == (a * b) / b
+        a.clone() == (a.clone() * b.clone().recip()) * b.clone() &&
+        a.clone() == (a.clone() * b.clone()) * b.clone().recip() &&
+        a.clone() == (a.clone() / b.clone()) * b.clone() &&
+        a.clone() == (a.clone() * b.clone()) / b.clone()
 
         // TODO: psuedo inverse?
     }
@@ -131,14 +128,12 @@ mod tests {
             }
         }
     }
-    check_int!(u8)
-    check_int!(u16)
-    check_int!(u32)
-    check_int!(u64)
-    check_int!(uint)
-    check_int!(i8)
-    check_int!(i16)
-    check_int!(i32)
-    check_int!(i64)
-    check_int!(int)
+    //check_int!(u8);
+    //check_int!(u16);
+    //check_int!(u32);
+    //check_int!(u64);
+    check_int!(i8);
+    check_int!(i16);
+    check_int!(i32);
+    check_int!(i64);
 }

--- a/src/structure/semigroup.rs
+++ b/src/structure/semigroup.rs
@@ -32,7 +32,7 @@ pub trait SemigroupAdditiveApprox
     fn prop_add_is_associative_approx(args: (Self, Self, Self)) -> bool {
         // TODO: use ApproxEq
         let (a, b, c) = args;
-        (a + b) + c == a + (b + c)
+        (a.clone() + b.clone()) + c.clone() == a + (b + c)
     }
 }
 
@@ -40,12 +40,10 @@ impl SemigroupAdditiveApprox for u8   {}
 impl SemigroupAdditiveApprox for u16  {}
 impl SemigroupAdditiveApprox for u32  {}
 impl SemigroupAdditiveApprox for u64  {}
-impl SemigroupAdditiveApprox for uint {}
 impl SemigroupAdditiveApprox for i8   {}
 impl SemigroupAdditiveApprox for i16  {}
 impl SemigroupAdditiveApprox for i32  {}
 impl SemigroupAdditiveApprox for i64  {}
-impl SemigroupAdditiveApprox for int  {}
 
 /// A type that is closed over an associative addition operator.
 ///
@@ -62,7 +60,7 @@ pub trait SemigroupAdditive
     /// arguments.
     fn prop_add_is_associative(args: (Self, Self, Self)) -> bool {
         let (a, b, c) = args;
-        (a + b) + c == a + (b + c)
+        (a.clone() + b.clone()) + c.clone() == a + (b + c)
     }
 }
 
@@ -70,12 +68,10 @@ impl SemigroupAdditive for u8   {}
 impl SemigroupAdditive for u16  {}
 impl SemigroupAdditive for u32  {}
 impl SemigroupAdditive for u64  {}
-impl SemigroupAdditive for uint {}
 impl SemigroupAdditive for i8   {}
 impl SemigroupAdditive for i16  {}
 impl SemigroupAdditive for i32  {}
 impl SemigroupAdditive for i64  {}
-impl SemigroupAdditive for int  {}
 
 /// A type that is closed over an approximately associative multiplication operator.
 ///
@@ -92,7 +88,7 @@ pub trait SemigroupMultiplicativeApprox
     fn prop_mul_is_associative_approx(args: (Self, Self, Self)) -> bool {
         // TODO: use ApproxEq
         let (a, b, c) = args;
-        (a * b) * c == a * (b * c)
+        (a.clone() * b.clone()) * c.clone() == a * (b * c)
     }
 }
 
@@ -100,12 +96,10 @@ impl SemigroupMultiplicativeApprox for u8   {}
 impl SemigroupMultiplicativeApprox for u16  {}
 impl SemigroupMultiplicativeApprox for u32  {}
 impl SemigroupMultiplicativeApprox for u64  {}
-impl SemigroupMultiplicativeApprox for uint {}
 impl SemigroupMultiplicativeApprox for i8   {}
 impl SemigroupMultiplicativeApprox for i16  {}
 impl SemigroupMultiplicativeApprox for i32  {}
 impl SemigroupMultiplicativeApprox for i64  {}
-impl SemigroupMultiplicativeApprox for int  {}
 
 /// A type that is closed over an associative multiplication operator.
 ///
@@ -122,7 +116,7 @@ pub trait SemigroupMultiplicative
     /// arguments.
     fn prop_mul_is_associative(args: (Self, Self, Self)) -> bool {
         let (a, b, c) = args;
-        (a * b) * c == a * (b * c)
+        (a.clone() * b.clone()) * c.clone() == a * (b * c)
     }
 }
 
@@ -130,12 +124,10 @@ impl SemigroupMultiplicative for u8   {}
 impl SemigroupMultiplicative for u16  {}
 impl SemigroupMultiplicative for u32  {}
 impl SemigroupMultiplicative for u64  {}
-impl SemigroupMultiplicative for uint {}
 impl SemigroupMultiplicative for i8   {}
 impl SemigroupMultiplicative for i16  {}
 impl SemigroupMultiplicative for i32  {}
 impl SemigroupMultiplicative for i64  {}
-impl SemigroupMultiplicative for int  {}
 
 #[cfg(test)]
 mod tests {
@@ -167,14 +159,12 @@ mod tests {
             }
         }
     }
-    check_int!(u8)
-    check_int!(u16)
-    check_int!(u32)
-    check_int!(u64)
-    check_int!(uint)
-    check_int!(i8)
-    check_int!(i16)
-    check_int!(i32)
-    check_int!(i64)
-    check_int!(int)
+    check_int!(u8);
+    check_int!(u16);
+    check_int!(u32);
+    check_int!(u64);
+    check_int!(i8);
+    check_int!(i16);
+    check_int!(i32);
+    check_int!(i64);
 }


### PR DESCRIPTION
Changes:
* added `Sized` constraint to some basic traits, otherwise test functions would not compile
* added `Clone` constraints and `.clone()` calls to prevent "use of previously moved value"
* commented out impls and tests requiring unsigned types to be `Neg`, which they aren't

Some tests still don't pass because of overflow errors - I don't currently have any idea how to fix it, because it would require everything to use `Wrapping<T>`.