### PR TITLE
Updated ApproxEq to use associated type.

### DIFF
--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -13,71 +13,45 @@
 // limitations under the License.
 
 /// A type with an approximate equivalence relation.
-pub trait ApproxEq<Eps> : Sized {
+pub trait ApproxEq {
+    type Eps: Sized;
+
     /// The default epsilon value to use in `ApproxEq::approx_eq`.
-    fn default_epsilon(_: Option<Self>) -> Eps;
+    fn default_epsilon() -> Self::Eps;
 
     /// Compare `a` and `b` for approximate equality using the specified
     /// epsilon value.
-    fn approx_eq_eps(a: &Self, b: &Self, epsilon: &Eps) -> bool;
+    fn approx_eq_eps(a: &Self, b: &Self, epsilon: &Self::Eps) -> bool;
 
     /// Compare `a` and `b` for approximate equality using the default
     /// epsilon value returned by `ApproxEq::default_epsilon`.
     #[inline]
     fn approx_eq(a: &Self, b: &Self) -> bool {
-        ApproxEq::approx_eq_eps(a, b, &ApproxEq::default_epsilon(None::<Self>))
+        Self::approx_eq_eps(a, b, &Self::default_epsilon())
     }
 }
 
-macro_rules! impl_approx_eq_for_uint {
-    ($T:ty) => {
-        impl ApproxEq<$T> for $T {
+macro_rules! impl_approx_eq {
+    ($T:ty, $V:expr) => {
+        impl ApproxEq for $T {
+            type Eps = $T;
             #[inline]
-            fn default_epsilon(_: Option<$T>) -> $T { 0 }
+            fn default_epsilon() -> $T { $V }
             #[inline]
             fn approx_eq_eps(a: &$T, b: &$T, epsilon: &$T) -> bool {
                 (*a - *b) < *epsilon
             }
         }
-
     }
 }
 
-macro_rules! impl_approx_eq_for_int {
-    ($T:ty) => {
-        impl ApproxEq<$T> for $T {
-            #[inline]
-            fn default_epsilon(_: Option<$T>) -> $T { 0 }
-            #[inline]
-            fn approx_eq_eps(a: &$T, b: &$T, epsilon: &$T) -> bool {
-                (*a - *b).abs() < *epsilon
-            }
-        }
-
-    }
-}
-
-macro_rules! impl_approx_eq_for_float {
-    ($T:ty) => {
-        impl ApproxEq<$T> for $T {
-            #[inline]
-            fn default_epsilon(_: Option<$T>) -> $T { 1.0e-6 }
-            #[inline]
-            fn approx_eq_eps(a: &$T, b: &$T, epsilon: &$T) -> bool {
-                (*a - *b).abs() < *epsilon
-            }
-        }
-
-    }
-}
-
-impl_approx_eq_for_uint!(u8);
-impl_approx_eq_for_uint!(u16);
-impl_approx_eq_for_uint!(u32);
-impl_approx_eq_for_uint!(u64);
-impl_approx_eq_for_int!(i8);
-impl_approx_eq_for_int!(i16);
-impl_approx_eq_for_int!(i32);
-impl_approx_eq_for_int!(i64);
-impl_approx_eq_for_float!(f32);
-impl_approx_eq_for_float!(f64);
+impl_approx_eq!(u8, 0);
+impl_approx_eq!(u16, 0);
+impl_approx_eq!(u32, 0);
+impl_approx_eq!(u64, 0);
+impl_approx_eq!(i8, 0);
+impl_approx_eq!(i16, 0);
+impl_approx_eq!(i32, 0);
+impl_approx_eq!(i64, 0);
+impl_approx_eq!(f32, 1.0e-6);
+impl_approx_eq!(f64, 1.0e-6);

--- a/src/structure/magma.rs
+++ b/src/structure/magma.rs
@@ -14,6 +14,8 @@
 
 use std::ops::{Add, Mul};
 
+use cmp::ApproxEq;
+
 /// An additive closure that forms a partial equivalence relation.
 ///
 /// ~~~notrust
@@ -22,14 +24,14 @@ use std::ops::{Add, Mul};
 /// ~~~
 pub trait MagmaAdditiveApprox
     : Add<Self, Output=Self>
-//  + ApproxEq (TODO: requires better support for associated types)
+    + ApproxEq
     + PartialEq
     + Sized
     + Clone
 {}
 
 impl<T> MagmaAdditiveApprox for T where
-    T: Add<T, Output=T> /*+ ApproxEq*/ + PartialEq + Clone,
+    T: Add<T, Output=T> + ApproxEq + PartialEq + Clone,
 {}
 
 /// An additive closure that forms an equivalence relation.
@@ -55,14 +57,14 @@ impl<T> MagmaAdditive for T where
 /// ~~~
 pub trait MagmaMultiplicativeApprox
     : Mul<Self, Output=Self>
-//  + ApproxEq (TODO: requires better support for associated types)
+    + ApproxEq
     + PartialEq
     + Sized
     + Clone
 {}
 
 impl<T> MagmaMultiplicativeApprox for T where
-    T: Mul<T, Output=T> /*+ ApproxEq*/ + PartialEq + Clone,
+    T: Mul<T, Output=T> + ApproxEq + PartialEq + Clone,
 {}
 
 /// A multiplicative closure that forms an equivalence relation.


### PR DESCRIPTION
This updates ApproxEq trait to use associated type for epsilon and also simplifies macro for implementing the trait. This doesn't change the floating pointer equality checking to use ULPs, use asserts or move the macro to separate crate as mentioned in #14.